### PR TITLE
Add AutoGenerateBindingRedirects

### DIFF
--- a/DesktopToast.Wpf/DesktopToast.Wpf.csproj
+++ b/DesktopToast.Wpf/DesktopToast.Wpf.csproj
@@ -14,6 +14,7 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkProfile />
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Fixes the compiler warning for DesktopToast.Wpf.csproj